### PR TITLE
Mixture fraction bug fixes

### DIFF
--- a/Exec/RegTests/airJet/pelelmex_prob.H
+++ b/Exec/RegTests/airJet/pelelmex_prob.H
@@ -33,7 +33,7 @@ pelelmex_initdata (int i, int j, int k,
     AMREX_D_TERM(const amrex::Real Lxm = .5*(prob_hi[0] + prob_lo[0]);
 		 , const amrex::Real Lym = .5*(prob_hi[1] + prob_lo[1]);
 		 , const amrex::Real Lzm = .5*(prob_hi[2] + prob_lo[2]));
-    
+
     amrex::Real x[3] = {
       prob_lo[0] + static_cast<amrex::Real>(i + 0.5) * dx[0],
       prob_lo[1] + static_cast<amrex::Real>(j + 0.5) * dx[1],
@@ -43,22 +43,17 @@ pelelmex_initdata (int i, int j, int k,
     amrex::Real eta = 0.5*(1.0 - std::tanh(2.0*(radius-prob_parm.D*0.5)/(0.3*prob_parm.D*0.5)));
 
     amrex::Real enthalpy_cgs = (1.0-eta) * prob_parm.H_fuel + eta*prob_parm.H_ox;
-    if(radius < prob_parm.D*0.5){
-       enthalpy_cgs = prob_parm.H_ox;
-    }
-    else{
-       enthalpy_cgs = prob_parm.H_fuel;
-    }
-    
+
     for (int n = 0; n < NUM_SPECIES; n++)
     {
         massfrac[n] = prob_parm.Y_ox[n];
     }
 
-    amrex::Real T;
+    amrex::Real T = 300.0;
     eos.HY2T(enthalpy_cgs, massfrac, T);
+    if( std::isnan(T)) {amrex::Abort("T is nan");}
     state(i,j,k,TEMP) = T;
-    
+
     state(i,j,k,VELX) = 0.1;
     state(i,j,k,VELY) = 0.0;
     state(i,j,k,VELZ) = 0.0;
@@ -77,13 +72,13 @@ pelelmex_initdata (int i, int j, int k,
 
 #ifdef PELELM_USE_MF
     if(radius < prob_parm.D*0.5){
-       state(i,j,k,FIRSTMFVAR) = state(i,j,k,DENSITY); 
+       state(i,j,k,FIRSTMFVAR) = state(i,j,k,DENSITY);
     }
     else{
-       state(i,j,k,FIRSTMFVAR) = 0.0; 
+       state(i,j,k,FIRSTMFVAR) = 0.0;
     }
-    state(i,j,k,FIRSTMFVAR) = eta * state(i,j,k,DENSITY); 
-    state(i,j,k,FIRSTMFVAR+1) = 0.; 
+    state(i,j,k,FIRSTMFVAR) = eta * state(i,j,k,DENSITY);
+    state(i,j,k,FIRSTMFVAR+1) = 0.;
     state(i,j,k,FIRSTMFVAR+2) = 0.;
 #endif
 }
@@ -132,14 +127,15 @@ bcnormal(
     s_ext[VELX] = 0.0;
     s_ext[VELY] = 0.0;
     s_ext[VELZ] = eta*prob_parm.v_in;
-    
+
     for (int n = 0; n < NUM_SPECIES; n++)
     {
       massfrac[n] = prob_parm.Y_ox[n];
     }
     enthalpy = (1.-eta) * prob_parm.H_fuel + eta*prob_parm.H_ox;
 
-    GET_T_GIVEN_HY(enthalpy,massfrac,s_ext[TEMP],ierr);
+    s_ext[TEMP] = 300.0;
+    eos.HY2T(enthalpy,massfrac,s_ext[TEMP]);
 
     amrex::Real rho_cgs, P_cgs, RhoH_temp;
     P_cgs = prob_parm.P_mean * 10.0;

--- a/Exec/RegTests/airJet/pelelmex_prob.cpp
+++ b/Exec/RegTests/airJet/pelelmex_prob.cpp
@@ -34,8 +34,9 @@ void PeleLM::readProbParm()
        prob_parm->Y_fuel[n] = prob_parm->Y_ox[n];
    }
 
-   CKHBMS(prob_parm->T_fu, prob_parm->Y_fuel, prob_parm->H_fuel);
-   CKHBMS(prob_parm->T_ox, prob_parm->Y_ox,   prob_parm->H_ox);
+   auto eos = pele::physics::PhysicsType::eos();
+   eos.TY2H(prob_parm->T_fu, prob_parm->Y_fuel, prob_parm->H_fuel);
+   eos.TY2H(prob_parm->T_ox, prob_parm->Y_ox,   prob_parm->H_ox);
 
    auto problo = geom[0].ProbLo();
    auto probhi = geom[0].ProbHi();

--- a/Source/PeleLMeX_Diffusion.cpp
+++ b/Source/PeleLMeX_Diffusion.cpp
@@ -81,8 +81,7 @@ PeleLM::computeDifferentialDiffusionTerms(
 #ifdef PELELM_USE_MF
       fluxes[lev][idim].define(
         amrex::convert(ba, IntVect::TheDimensionVector(idim)), dmap[lev],
-        NVAR, nGrow, MFInfo(), factory);
-        // NUM_SPECIES + 2 + NUMMFVAR, nGrow, MFInfo(), factory);
+        NUM_SPECIES + 2 + NUMMFVAR, nGrow, MFInfo(), factory);
 #else
       fluxes[lev][idim].define(
         amrex::convert(ba, IntVect::TheDimensionVector(idim)), dmap[lev],
@@ -148,17 +147,16 @@ PeleLM::computeDifferentialDiffusionTerms(
     GetVecOfConstPtrs(getSpeciesVect(a_time)), 0, diffTermVec, 0,
     GetVecOfArrOfPtrs(fluxes), 0, {}, 0, NUM_SPECIES, intensiveFluxes,
     bcRecSpec_d.dataPtr(), -1.0, m_dt);
+
 #ifdef PELELM_USE_MF
   auto bcRecMF = fetchBCRecArray(FIRSTMFVAR,NUMMFVAR);
   auto bcRecMF_d = convertToDeviceVector(bcRecMF);
-
-
   fluxDivergenceRD(
-    GetVecOfConstPtrs(getMFVect(a_time)), 0, diffTermVec, 0,
-    GetVecOfArrOfPtrs(fluxes), 0, {}, 0, NUMMFVAR, intensiveFluxes,
+    GetVecOfConstPtrs(getMFVect(a_time)), 0, diffTermVec, NUM_SPECIES + 2,
+    GetVecOfArrOfPtrs(fluxes), NUM_SPECIES + 2, {}, 0, NUMMFVAR, intensiveFluxes,
     bcRecMF_d.dataPtr(), -1.0, m_dt);
-
 #endif
+
   auto bcRecTemp = fetchBCRecArray(TEMP, 1);
   auto bcRecTemp_d = convertToDeviceVector(bcRecTemp);
   Vector<MultiFab*> EBFluxesVec =

--- a/Source/PeleLMeX_K.H
+++ b/Source/PeleLMeX_K.H
@@ -804,7 +804,7 @@ buildAdvectionForcing(
 
 #ifdef PELELM_USE_MF
   for (int m = 0; m < NUMMFVAR; m++) {
-    forceMF(i, j, k, m) = dn(i, j, k, FIRSTMFVAR + m);
+    forceMF(i, j, k, m) = dn(i, j, k, NUM_SPECIES + 2 + m);
   }
   //#ifdef PELELM_USE_AGE
   //forceMF(i,j,k,NUMMFVAR-1) += r(i,j,k,NUM_SPECIES);


### PR DESCRIPTION
- Fixes some indexing errors depending on how arrays are defined (e.g. having all state variables or just scalars)
- initialize T before calling HY2T (or GET_T_FROM_HY) because this function uses the input value of T to start iteration
- modernize thermo calls by using EOS rather then lower level functions (not strictly necessary)

Some other notes:

- you'll need to modify index definition logic in PeleLMeX_Index.H to get this to work with Soot/Efield I think
- Most of the `#ifdefs` can probably be avoided (when NUMMFVARS=0 a lot of code become equivalent to the code without MF capability)

Once this is fully debugged, please submit as a PR to the main branch! If you do, I'd recommend a different naming convention as MF may be confused as an abbreviation for MultiFab and this capability could be used for variables besides mixture fraction (as you have for age). I'd recommend to rename to names with AUX instead of MF.